### PR TITLE
change import paths to github.com/tailscale/netlink

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ before_script:
   - sudo modprobe sch_sfq
 install:
   - go get -v -t ./...
-go_import_path: github.com/vishvananda/netlink
+go_import_path: github.com/tailscale/netlink

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ $(call goroot,$(DEPS)):
 
 .PHONY: $(call testdirs,$(DIRS))
 $(call testdirs,$(DIRS)):
-	go test -test.exec sudo -test.parallel 4 -timeout 60s -test.v github.com/vishvananda/netlink/$@
+	go test -test.exec sudo -test.parallel 4 -timeout 60s -test.v github.com/tailscale/netlink/$@
 
 $(call fmt,$(call testdirs,$(DIRS))):
 	! gofmt -l $(subst fmt-,,$@)/*.go | grep -q .

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # netlink - netlink library for go #
 
-[![Build Status](https://app.travis-ci.com/vishvananda/netlink.svg?branch=master)](https://app.travis-ci.com/github/vishvananda/netlink) [![GoDoc](https://godoc.org/github.com/vishvananda/netlink?status.svg)](https://godoc.org/github.com/vishvananda/netlink)
+[![Build Status](https://app.travis-ci.com/vishvananda/netlink.svg?branch=master)](https://app.travis-ci.com/github/vishvananda/netlink) [![GoDoc](https://godoc.org/github.com/tailscale/netlink?status.svg)](https://godoc.org/github.com/tailscale/netlink)
 
 The netlink package provides a simple netlink library for go. Netlink
 is the interface a user-space program in linux uses to communicate with
@@ -20,7 +20,7 @@ functionality like ipsec xfrm handling.
 
 You can use go get command:
 
-    go get github.com/vishvananda/netlink
+    go get github.com/tailscale/netlink
 
 Testing dependencies:
 
@@ -28,7 +28,7 @@ Testing dependencies:
 
 Testing (requires root):
 
-    sudo -E go test github.com/vishvananda/netlink
+    sudo -E go test github.com/tailscale/netlink
 
 ## Examples ##
 
@@ -39,7 +39,7 @@ package main
 
 import (
     "fmt"
-    "github.com/vishvananda/netlink"
+    "github.com/tailscale/netlink"
 )
 
 func main() {
@@ -66,7 +66,7 @@ Add a new ip address to loopback:
 package main
 
 import (
-    "github.com/vishvananda/netlink"
+    "github.com/tailscale/netlink"
 )
 
 func main() {

--- a/addr_linux.go
+++ b/addr_linux.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
 )

--- a/bridge_linux.go
+++ b/bridge_linux.go
@@ -3,7 +3,7 @@ package netlink
 import (
 	"fmt"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/class_linux.go
+++ b/class_linux.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"syscall"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/cmd/ipset-test/main.go
+++ b/cmd/ipset-test/main.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package main
@@ -10,7 +11,7 @@ import (
 	"os"
 	"sort"
 
-	"github.com/vishvananda/netlink"
+	"github.com/tailscale/netlink"
 )
 
 type command struct {

--- a/conntrack_linux.go
+++ b/conntrack_linux.go
@@ -8,7 +8,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/conntrack_test.go
+++ b/conntrack_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package netlink
@@ -11,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
 )

--- a/devlink_linux.go
+++ b/devlink_linux.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/filter_linux.go
+++ b/filter_linux.go
@@ -9,7 +9,7 @@ import (
 	"net"
 	"syscall"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 
@@ -53,7 +53,8 @@ func (filter *U32) Type() string {
 
 // Fw filter filters on firewall marks
 // NOTE: this is in filter_linux because it refers to nl.TcPolice which
-//       is defined in nl/tc_linux.go
+//
+//	is defined in nl/tc_linux.go
 type Fw struct {
 	FilterAttrs
 	ClassId uint32

--- a/fou_linux.go
+++ b/fou_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package netlink
@@ -6,7 +7,7 @@ import (
 	"encoding/binary"
 	"errors"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/genetlink_linux.go
+++ b/genetlink_linux.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"syscall"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/gtp_linux.go
+++ b/gtp_linux.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/handle_linux.go
+++ b/handle_linux.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
 )

--- a/handle_test.go
+++ b/handle_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package netlink
@@ -14,7 +15,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
 )

--- a/ipset_linux.go
+++ b/ipset_linux.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"syscall"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/ipset_linux_test.go
+++ b/ipset_linux_test.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"testing"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/link_linux.go
+++ b/link_linux.go
@@ -12,7 +12,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
 )

--- a/link_test.go
+++ b/link_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package netlink
@@ -12,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
 )

--- a/neigh_linux.go
+++ b/neigh_linux.go
@@ -6,7 +6,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
 )

--- a/netlink_linux.go
+++ b/netlink_linux.go
@@ -1,6 +1,6 @@
 package netlink
 
-import "github.com/vishvananda/netlink/nl"
+import "github.com/tailscale/netlink/nl"
 
 // Family type definitions
 const (

--- a/netns_linux.go
+++ b/netns_linux.go
@@ -15,7 +15,7 @@ package netlink
 import (
 	"fmt"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/order.go
+++ b/order.go
@@ -3,7 +3,7 @@ package netlink
 import (
 	"encoding/binary"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 )
 
 var (

--- a/protinfo_linux.go
+++ b/protinfo_linux.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"syscall"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/qdisc_linux.go
+++ b/qdisc_linux.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/rdma_link_linux.go
+++ b/rdma_link_linux.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 
@@ -307,6 +307,7 @@ func (h *Handle) RdmaLinkDel(name string) error {
 
 // RdmaLinkAdd adds an rdma link for the specified type to the network device.
 // Similar to: rdma link add NAME type TYPE netdev NETDEV
+//
 //	NAME - specifies the new name of the rdma link to add
 //	TYPE - specifies which rdma type to use.  Link types:
 //		rxe - Soft RoCE driver

--- a/route_linux.go
+++ b/route_linux.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
 )

--- a/route_test.go
+++ b/route_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package netlink
@@ -8,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
 )

--- a/rule_linux.go
+++ b/rule_linux.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/socket_linux.go
+++ b/socket_linux.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"syscall"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/xfrm_monitor_linux.go
+++ b/xfrm_monitor_linux.go
@@ -3,7 +3,7 @@ package netlink
 import (
 	"fmt"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
 )

--- a/xfrm_monitor_test.go
+++ b/xfrm_monitor_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package netlink
@@ -5,7 +6,7 @@ package netlink
 import (
 	"testing"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 )
 
 func TestXfrmMonitorExpire(t *testing.T) {

--- a/xfrm_policy_linux.go
+++ b/xfrm_policy_linux.go
@@ -1,7 +1,7 @@
 package netlink
 
 import (
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 

--- a/xfrm_state_linux.go
+++ b/xfrm_state_linux.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"unsafe"
 
-	"github.com/vishvananda/netlink/nl"
+	"github.com/tailscale/netlink/nl"
 	"golang.org/x/sys/unix"
 )
 


### PR DESCRIPTION
This removes any dependency on github.com/vishvananda/netlink, which has evolved well beyond our fork and is no longer API compatible with it.

Fixes tailscale/tailscale#12298